### PR TITLE
FIX: navigator-toolbox not visible after Zen update 1.0.2-b.2

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -25,7 +25,7 @@
     --tab-outwards-direction: rtl;
     --tab-inwards-direction: ltr;
     --tab-hover-background-base-color: color-mix(in lch, var(--zen-navigator-toolbox-background, light-dark(#E5E5E5, #303030)) 35%, transparent);
-    z-index: 4;
+    z-index: 4 !important;
 
     .tabbrowser-tab {
       animation: none !important;


### PR DESCRIPTION
Hi, thanks for the mod I've been using it for some time. After updating Zen to version 1.0.2-b.2 today on macOS, the tab background wasn't visible anymore.

I first tried to set the z-index to 9999 with no success. Then restoring it to its original value of 4 but adding !important solved it for me.
I am no CSS expert, maybe you know of a better solution?
